### PR TITLE
fixed broken esp-zboss-lib dependency from "~0.3.0" to "^0.4.0"

### DIFF
--- a/examples/esp_zigbee_HA_sample/HA_color_dimmable_light/main/idf_component.yml
+++ b/examples/esp_zigbee_HA_sample/HA_color_dimmable_light/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   espressif/led_strip: "~2.0.0"
   ## Required IDF version
   idf:

--- a/examples/esp_zigbee_HA_sample/HA_color_dimmable_switch/main/idf_component.yml
+++ b/examples/esp_zigbee_HA_sample/HA_color_dimmable_switch/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   ## Required IDF version
   idf:
     version: ">=5.0.0"

--- a/examples/esp_zigbee_HA_sample/HA_on_off_light/main/idf_component.yml
+++ b/examples/esp_zigbee_HA_sample/HA_on_off_light/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   espressif/led_strip: "~2.0.0"
   ## Required IDF version
   idf:

--- a/examples/esp_zigbee_HA_sample/HA_on_off_switch/main/idf_component.yml
+++ b/examples/esp_zigbee_HA_sample/HA_on_off_switch/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   ## Required IDF version
   idf:
     version: ">=5.0.0"

--- a/examples/esp_zigbee_cli/main/idf_component.yml
+++ b/examples/esp_zigbee_cli/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   ## Required IDF version
   idf:
     version: ">=5.0.0"

--- a/examples/esp_zigbee_customized_devices/customized_client/main/idf_component.yml
+++ b/examples/esp_zigbee_customized_devices/customized_client/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   ## Required IDF version
   idf:
     version: ">=5.0.0"

--- a/examples/esp_zigbee_customized_devices/customized_server/main/idf_component.yml
+++ b/examples/esp_zigbee_customized_devices/customized_server/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   espressif/led_strip: "~2.0.0"
   ## Required IDF version
   idf:

--- a/examples/esp_zigbee_gateway/main/idf_component.yml
+++ b/examples/esp_zigbee_gateway/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   espressif/esp_rcp_update: "~0.3.0"
   espressif/esp-serial-flasher: "~0.0.4"
   ## Required IDF version

--- a/examples/esp_zigbee_ota/ota_client/main/idf_component.yml
+++ b/examples/esp_zigbee_ota/ota_client/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   ## Required IDF version
   idf:
     version: ">=5.0.0"

--- a/examples/esp_zigbee_ota/ota_server/main/idf_component.yml
+++ b/examples/esp_zigbee_ota/ota_server/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   ## Required IDF version
   idf:
     version: ">=5.0.0"

--- a/examples/esp_zigbee_rcp/main/idf_component.yml
+++ b/examples/esp_zigbee_rcp/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.3.0"
+  espressif/esp-zboss-lib: "^0.4.0"
   ## Required IDF version
   idf:
     version: ">=5.0.0"


### PR DESCRIPTION
all the examples had the dependency of esp-zboss-lib~0.3.0 and the build failed at linking: ../managed_components/espressif__esp-zboss-lib/lib/esp32c6/libzboss_port.a(zb_esp_mac.c.obj): in function `.L0 ':
(.text.zb_transceiver_set_channel+0x4): undefined reference to `esp_ieee802154_set_channnel'