### PR TITLE
Memory allocation bug fixed in esp_delta_ota_ops.c (TZ-1410)

### DIFF
--- a/examples/common/delta_ota/src/esp_delta_ota_ops.c
+++ b/examples/common/delta_ota/src/esp_delta_ota_ops.c
@@ -133,7 +133,7 @@ esp_err_t esp_delta_ota_begin(const esp_partition_t *partition, size_t image_siz
 
     s_delta_ota_ctx = calloc(1, sizeof(esp_delta_ota_ctx_t));
     assert(s_delta_ota_ctx);
-    s_delta_ota_ctx->header_data = calloc(1, sizeof(DELTA_OTA_UPGRADE_IMAGE_HEADER_SIZE));
+    s_delta_ota_ctx->header_data = calloc(1, DELTA_OTA_UPGRADE_IMAGE_HEADER_SIZE);
     assert(s_delta_ota_ctx->header_data);
 
     *out_handle = ota_handle;


### PR DESCRIPTION
In esp_delta_ota_ops.c, there was a bug when allocating memory for s_delta_ota_ctx->header_data.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
