### PR TITLE
Add light sensor default config (TZ-1519)

### DIFF
--- a/components/esp-zigbee-lib/include/ha/esp_zigbee_ha_standard.h
+++ b/components/esp-zigbee-lib/include/ha/esp_zigbee_ha_standard.h
@@ -386,6 +386,29 @@ extern "C" {
             },                                                                                      \
     }
 
+ /**
+  * @brief Zigbee HA light sensor device default config value.
+  *
+  */
+#define ESP_ZB_DEFAULT_LIGHT_SENSOR_CONFIG()                                          \
+    {                                                                                               \
+        .basic_cfg =                                                                                \
+            {                                                                                       \
+                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                          \
+                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                        \
+            },                                                                                      \
+        .identify_cfg =                                                                             \
+            {                                                                                       \
+                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                   \
+            },                                                                                      \
+        .illuminance_cfg =                                                                              \
+            {                                                                                           \
+                .measured_value = ESP_ZB_ZCL_ILLUMINANCE_MEASUREMENT_LIGHT_SENSOR_TYPE_DEFAULT_VALUE,   \
+                .min_value = ESP_ZB_ZCL_ILLUMINANCE_MEASUREMENT_LIGHT_SENSOR_TYPE_DEFAULT_VALUE,        \
+                .max_value = ESP_ZB_ZCL_ILLUMINANCE_MEASUREMENT_LIGHT_SENSOR_TYPE_DEFAULT_VALUE,        \
+            },                                                                                          \
+    }
+
 /********************************* Declare functions **************************************/
 
 /***************************** ZCL HA device standard cluster list ********************************/


### PR DESCRIPTION
## Description

Added light sensor default config to ha_standard file, needed for creating light sensor devices. Technically the default values may not be ideal as there isn't an option for a null default value like there is for the temperature sensor, but it does work just fine. 

## Testing

I created a Zigbee light sensor using the Arduino core using this default configuration. Works as expected.