### PR TITLE
Add support for ms commands to `zcl send_raw`

### DIFF
--- a/components/esp-zigbee-console/src/cli_cmd_zcl.c
+++ b/components/esp-zigbee-console/src/cli_cmd_zcl.c
@@ -862,14 +862,16 @@ static esp_err_t cli_zcl_send_raw(esp_zb_cli_cmd_t *self, int argc, char **argv)
         esp_zb_cli_aps_argtable_t aps;
         arg_str_t  *peer_role;
         arg_u8_t   *command;
+        arg_u16_t  *manuf_code;
         arg_hex_t  *payload;
         arg_lit_t  *dry_run;
         arg_end_t  *end;
     } argtable = {
-        .peer_role = arg_strn("r",  "role",     "<sc:C|S>",    0, 1, "role of the peer cluster, default: S"),
-        .command   = arg_u8n(NULL,  "cmd",      "<u8:CMD_ID>", 1, 1, "identifier of the command"),
-        .payload   = arg_hexn("p",  "payload",  "<hex:DATA>",  0, 1, "ZCL payload of the command, raw HEX data"),
-        .dry_run   = arg_lit0("n",  "dry-run", "print the request being sent"),
+        .peer_role  = arg_strn("r",  "role",     "<sc:C|S>",    0, 1, "role of the peer cluster, default: S"),
+        .command    = arg_u8n(NULL,  "cmd",      "<u8:CMD_ID>", 1, 1, "identifier of the command"),
+        .manuf_code = arg_u16n(NULL, "manuf",    "<u16:CODE>",  0, 1, "set manufacturer's code"),
+        .payload    = arg_hexn("p",  "payload",  "<hex:DATA>",  0, 1, "ZCL payload of the command, raw HEX data"),
+        .dry_run    = arg_lit0("n",  "dry-run",  "print the request being sent"),
         .end = arg_end(2),
     };
     esp_zb_cli_fill_aps_argtable(&argtable.aps);
@@ -894,6 +896,13 @@ static esp_err_t cli_zcl_send_raw(esp_zb_cli_cmd_t *self, int argc, char **argv)
                                            &req_params.zcl_basic_cmd.src_endpoint,
                                            &req_params.cluster_id,
                                            &req_params.profile_id));
+
+    if (argtable.manuf_code->count > 0) {
+        if (argtable.manuf_code->val[0] != ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC) {
+            req_params.manuf_specific = 1;
+            req_params.manuf_code = argtable.manuf_code->val[0];
+        }
+    }
 
     if (argtable.peer_role->count > 0) {
         switch (argtable.peer_role->sval[0][0]) {


### PR DESCRIPTION
## Description

Adds support for sending manufacturer-specific commands to clusters using `zcl send_raw`.

This is copied from `zcl send_gen` that already supports it.

## Testing

Trial by combat. I've ran it on esp32-c6 and successfully sent a command:

```
zcl send_raw -d 0x4db8 --dst-ep 10 -e 10 --profile 0x104 -c 0x0 --cmd 0x00 -p 0x8f010400 --manuf 0x131B
```

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
