### PR TITLE
Add support for setting trust center key (TZ-1820)

### DIFF
--- a/components/esp-zigbee-console/README.md
+++ b/components/esp-zigbee-console/README.md
@@ -49,6 +49,7 @@ For specific type of argument, correct format should be provided so that it can 
 - [`factoryreset`](#factoryreset): Reset the device to factory new.
 - [`ic`](#ic): Install code configuration.
 - [`iperf`](#iperf): Iperf over Zigbee.
+- [`linkkey`](#linkkey): Link Key Configuration.
 - [`macfilter`](#macfilter): Zigbee stack mac filter management.
 - [`neighbor`](#neighbor): Neighbor information.
 - [`network`](#network): Network configuration.
@@ -454,6 +455,55 @@ Dump iperf throughput on current node.
 ```bash
 esp> iperf result -r C -e 2
 iperf test throughput: 13 kbps
+```
+
+
+### linkkey
+Link Key Configuration.
+
+#### `linkkey add [-t <type:D|C>] [<hex:KEY128>]`
+Add an additional global link key.
+
+The optional `-t` (`--type`) argument determines the type of link
+key to set: Either `d` (distributed), or `c` (centralized).
+
+Default is `c`.
+
+Note: the implementation calls `esp_zb_secur_multi_TC_standard_preconfigure_key_add` (for centralized)
+or `esp_zb_secur_multi_standard_distributed_key_add` (for distributed).
+
+```bash
+linkkey add 0x0123456789abcdeffedcba9876543210
+```
+
+#### `linkkey remove [-t <type:D|C>] [<hex:KEY128>]`
+Remove an additional global link key.
+
+The optional `-t` (`--type`) argument determines the type of link
+key to set: Either `d` (distributed), or `c` (centralized).
+
+Default is `c`.
+
+Note: the implementation calls `esp_zb_secur_multi_TC_standard_preconfigure_key_remove` (for centralized)
+or `esp_zb_secur_multi_standard_distributed_key_remove` (for distributed).
+
+```bash
+linkkey add 0x0123456789abcdeffedcba9876543210
+```
+
+#### `linkkey set [-t <type:D|C>] [<hex:KEY128>]`
+Set the default global link key.
+
+The optional `-t` (`--type`) argument determines the type of trust center
+key to set: Either `d` (distributed), or `c` (centralized).
+
+Default is `c`.
+
+Note: the implementation calls `esp_zb_secur_TC_standard_preconfigure_key_set` (for centralized)
+or `esp_zb_secur_TC_standard_distributed_key_set` (for distributed).
+
+```bash
+linkkey set 0x0123456789abcdeffedcba9876543210
 ```
 
 

--- a/components/esp-zigbee-console/src/cli_cmd_bdb.c
+++ b/components/esp-zigbee-console/src/cli_cmd_bdb.c
@@ -483,6 +483,101 @@ exit:
     return ret;
 }
 
+/* Sub-commands of `linkkey` */
+
+typedef enum linkkey_op_s {
+    LKO_add,
+    LKO_remove,
+    LKO_set,
+} linkkey_op_t;
+
+static esp_err_t cli_linkkey_op(linkkey_op_t op, esp_zb_cli_cmd_t *self, int argc, char **argv)
+{
+    struct {
+        arg_str_t *type;
+        arg_hex_t *key;
+        arg_lit_t *help;
+        arg_end_t *end;
+    } argtable = {
+        .type = arg_str0("t", "type", "<type:d|c>", "link key type: d: distributed, c: default global TC link key), default: c"),
+        .key = arg_hexn(NULL, NULL, "<key128:KEY>", 1, 1, "link key, in HEX format"),
+        .help = arg_lit0(NULL, "help", "Print this help message"),
+        .end = arg_end(2),
+    };
+    esp_err_t ret = ESP_OK;
+    bool centralized = true; // true if type: c
+
+    /* Parse command line arguments */
+    int nerrors = arg_parse(argc, argv, (void**)&argtable);
+    EXIT_ON_FALSE(argtable.help->count == 0, ESP_OK, arg_print_help((void**)&argtable, argv[0]));
+    EXIT_ON_FALSE(nerrors == 0, ESP_ERR_INVALID_ARG, arg_print_errors(stdout, argtable.end, argv[0]));
+
+    EXIT_ON_FALSE(argtable.key->hsize[0] == 16, ESP_ERR_INVALID_ARG);
+
+    if (argtable.type->count > 0) {
+        switch (argtable.type->sval[0][0]) {
+            case 'd':
+            case 'D':
+                centralized = false;
+                break;
+            case 'c':
+            case 'C':
+                centralized = true;
+                break;
+            default:
+                EXIT_ON_ERROR(ESP_ERR_INVALID_ARG, cli_output("%s: invalid argument to option --type\n", argv[0]));
+                break;
+        }
+    }
+
+    if (centralized) {
+        switch (op) {
+            case LKO_set:
+                esp_zb_secur_TC_standard_preconfigure_key_set(argtable.key->hval[0]);
+                break;
+            case LKO_add:
+                ret = esp_zb_secur_multi_TC_standard_preconfigure_key_add(argtable.key->hval[0]);
+                break;
+            case LKO_remove:
+                ret = esp_zb_secur_multi_TC_standard_preconfigure_key_remove(argtable.key->hval[0]);
+                break;
+        }
+    } else {
+        switch (op) {
+            case LKO_set:
+                esp_zb_secur_TC_standard_distributed_key_set(argtable.key->hval[0]);
+                break;
+            case LKO_add:
+                ret = esp_zb_secur_multi_standard_distributed_key_add(argtable.key->hval[0]);
+                break;
+            case LKO_remove:
+                ret = esp_zb_secur_multi_standard_distributed_key_remove(argtable.key->hval[0]);
+                break;
+        }
+    }
+
+exit:
+    arg_hex_free(argtable.key);
+    ESP_ZB_CLI_FREE_ARGSTRUCT(&argtable);
+    return ret;
+}
+
+static esp_err_t cli_linkkey_add(esp_zb_cli_cmd_t *self, int argc, char **argv)
+{
+    return cli_linkkey_op(LKO_add, self, argc, argv);
+}
+
+static esp_err_t cli_linkkey_remove(esp_zb_cli_cmd_t *self, int argc, char **argv)
+{
+    return cli_linkkey_op(LKO_remove, self, argc, argv);
+}
+
+static esp_err_t cli_linkkey_set(esp_zb_cli_cmd_t *self, int argc, char **argv)
+{
+    return cli_linkkey_op(LKO_set, self, argc, argv);
+}
+
+
 /* Sub-commands of `ic` */
 
 static esp_err_t cli_ic_policy(esp_zb_cli_cmd_t *self, int argc, char **argv)
@@ -938,6 +1033,11 @@ DECLARE_ESP_ZB_CLI_CMD_WITH_SUB(network, "Network configuration",
     ESP_ZB_CLI_SUBCMD(close,    cli_nwk_close,    "Close local network"),
     ESP_ZB_CLI_SUBCMD(scan,     cli_nwk_scan,     "Scan for network"),
     ESP_ZB_CLI_SUBCMD(ed_scan,  cli_nwk_ed_scan,  "Scan for energy detect on channels"),
+);
+DECLARE_ESP_ZB_CLI_CMD_WITH_SUB(linkkey, "Link Key Configuration",
+    ESP_ZB_CLI_SUBCMD(add,    cli_linkkey_add,     "Add additional global link key"),
+    ESP_ZB_CLI_SUBCMD(remove, cli_linkkey_remove,  "Remove additional global link key"),
+    ESP_ZB_CLI_SUBCMD(set,    cli_linkkey_set,     "Set default global link key"),
 );
 DECLARE_ESP_ZB_CLI_CMD_WITH_SUB(ic, "Install code configuration",
     ESP_ZB_CLI_SUBCMD(policy, cli_ic_policy, "Set install code policy"),


### PR DESCRIPTION
## Description
Adds new command `linkkey set 0x00000000000000000000000000000000` to `esp-zigbee-console` that allows setting the global default link key. As well as `linkkey add` and `linkkey remove` for management of the additional global link keys.

Without this support it's challenging to join networks that use different Trust Center key.

## Testing

YOLO (tested live on my Hue network with esp32-c6)

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
