### PR TITLE
fix network scanning report (TZ-2115)

### DIFF
--- a/components/esp-zigbee-ncp/src/esp_ncp_zb.c
+++ b/components/esp-zigbee-ncp/src/esp_ncp_zb.c
@@ -202,7 +202,7 @@ static void esp_ncp_zb_bind_cb(esp_zb_zdp_status_t zdo_status, void *user_ctx)
     };
 
     typedef struct {
-        esp_zb_zdp_status_t    zdo_status;
+        uint8_t                zdo_status;
         esp_ncp_zb_user_cb_t   zdo_cb;                   /*!< A ZDO match desc request callback */
     } ESP_NCP_ZB_PACKED_STRUCT esp_ncp_zb_bind_parameters_t;
 


### PR DESCRIPTION
there was a bug in the pointer arithmetics.


## Description
calling the scan function would crash
```
I (27179) ESP_NCP_FRAME: 00 00 08 00 03 05 00 00 f8 ff 07 01 24 e4
I (27179) ESP_NCP_ZB: scan channel mask: 7fff800
I (27179) ESP_NCP_ZB: scan duration: 1
Guru Meditation Error: Core  0 panic'ed (Store access fault). Exception was unhandled.
```

## Testing

I'd be curioous to know how YOU tested the feature in the first place.

when I do a scan now it doesn't crash, doesn't reboot and send a notification on the link.
```
I (20700) ESP_NCP_FRAME: 00 00 08 00 03 05 00 00 f8 ff 07 01 24 e4
I (20700) ESP_NCP_ZB: scan channel mask: 7fff800
I (20700) ESP_NCP_ZB: scan duration: 1
I (21510) ESP_NCP_FRAME: sending notif: 09
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
