### PR TITLE
docs: fix migration guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The SDK is built on top of [ESP-IDF](https://github.com/espressif/esp-idf) and a
 [link-v2.x]: https://github.com/espressif/esp-zigbee-sdk/tree/main
 [link-dsr]: https://dsr-zoi.com
 
-If you are going to migrate from v1.x to v2.x, please refer to our [Migration Guide](https://docs.espressif.com/projects/esp-zigbee-sdk/en/latest/esp32/migration-guide.html).
+If you are going to migrate from v1.x to v2.x, please refer to our [Migration Guide](https://docs.espressif.com/projects/esp-zigbee-sdk/en/latest/esp32/migration-guide/index.html).
 
 ![esp_zigbee_stack](docs/_static/esp_zigbee_sdk.svg)
 


### PR DESCRIPTION
## Summary

- fix the README migration guide URL so it points at the migration guide index page instead of the broken flat path

## Testing

- verified the docs tree ships `docs/en/migration-guide/index.rst`, so the generated docs path is the `migration-guide/index.html` route

Closes #801
